### PR TITLE
Added test folders and started smoke test example - see #6

### DIFF
--- a/test/basicapp/Dockerfile
+++ b/test/basicapp/Dockerfile
@@ -1,0 +1,7 @@
+
+FROM scratch
+EXPOSE 8000
+
+ADD basic-app /
+
+CMD ["/basic-app"]

--- a/test/basicapp/main.go
+++ b/test/basicapp/main.go
@@ -1,0 +1,16 @@
+package main
+
+
+import (
+	"io"
+	"net/http"
+)
+
+func hello(w http.ResponseWriter, r *http.Request) {
+	io.WriteString(w, "Hello Ploio. Safe, Reliable, and fast production deployments will come to you.")
+}
+
+func main() {
+	http.HandleFunc("/hi", hello)
+	http.ListenAndServe(":8000", nil)
+}

--- a/test/basicapp/v1/README.md
+++ b/test/basicapp/v1/README.md
@@ -1,0 +1,3 @@
+## Initial deployment for the test app
+
+This is just the initial deployment with included YAML and HELM charts for our basicapp test

--- a/test/basicapp/v1/yaml/deployment.yaml
+++ b/test/basicapp/v1/yaml/deployment.yaml
@@ -1,0 +1,21 @@
+
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: basicapp
+  annotations:
+    ploio.io/id: basicapp # If you want ploio to auto-deploy upgrades, need to add this annotation
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: basicapp
+        version: v1 # This has to be here for istio routing rules to work properly
+    spec:
+      containers:
+      - name: basicapp
+        image: weavelab/basicapp:v1
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8000

--- a/test/basicapp/v1/yaml/ingress.yaml
+++ b/test/basicapp/v1/yaml/ingress.yaml
@@ -1,0 +1,16 @@
+
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: basicapp-ingress
+  annotations:
+    kubernetes.io/ingress.class: "istio"
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /hi
+        backend:
+          serviceName: basicapp
+          servicePort: 8000
+---

--- a/test/basicapp/v1/yaml/service.yaml
+++ b/test/basicapp/v1/yaml/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: basicapp
+  labels:
+    app: basicapp
+spec:
+  ports:
+  - port: 8000
+    name: http
+  selector:
+    app: basicapp

--- a/test/basicapp/v2-canary/README.md
+++ b/test/basicapp/v2-canary/README.md
@@ -1,0 +1,1 @@
+## Canary test example yaml

--- a/test/basicapp/v2-rolling/README.md
+++ b/test/basicapp/v2-rolling/README.md
@@ -1,0 +1,1 @@
+# Rolling deploy sample yaml

--- a/test/basicapp/v2-smoke/README.md
+++ b/test/basicapp/v2-smoke/README.md
@@ -1,0 +1,12 @@
+## Smoke Deployment Test
+
+This folder contains all the changes that would be made when deploying v2 of our basicapp as a smoke test
+
+We have a duplicate of the original deployment with only these changes:
+
+1. Changed the version label to reflect v2
+2. Changed the docker image to be the updated code base
+3. Added istio default route for all normal traffic to go to v1 
+4. Added istio route for all traffic with a certain header to v2
+
+_NOTE: to make this work for services that may be several services deep, the header would have to propagate between services. It would be interesting to see if we could tie into standardized tracing headers from opentracing or the other one Derek loves so much from google. Then propagated headers/meta-data would already be instrumented._

--- a/test/basicapp/v2-smoke/ploio-version.yaml
+++ b/test/basicapp/v2-smoke/ploio-version.yaml
@@ -1,0 +1,28 @@
+apiVersion: "stable.ploio.io/v1"
+kind: PloioVersion
+metadata:
+  name: test-v1.0.0-smoke
+spec:
+  id: basicapp
+  image: weavelab/basicapp:v2
+  type: smoke  #canary|smoke|rolling
+  timeout: 5m
+  smoke-header-name: x-ploio
+  smoke-header-value-regex: (test)
+  # helm-chart-version-value:
+  # github-enabled: true
+  # github-issue-url:
+  # github-commit:
+  # canary-percentage: 5
+  # canary-metrics: []
+  # canary-prometheus-address:
+  
+  ###########################
+  # Fields below this are added programatically and updated by the ploiocontroller
+  ###########################
+  # state: pending | queued | running | failed | passed
+  # reason: 
+  # message: 
+  # create-time:
+  # last-update-time:
+  # end-time:

--- a/test/basicapp/v2-smoke/yaml/deployment-v2.yaml
+++ b/test/basicapp/v2-smoke/yaml/deployment-v2.yaml
@@ -1,0 +1,19 @@
+
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: basicapp-v2
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: basicapp
+        version: v2
+    spec:
+      containers:
+      - name: basicapp
+        image: weavelab/basicapp:v2
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8000

--- a/test/basicapp/v2-smoke/yaml/deployment-v2.yaml
+++ b/test/basicapp/v2-smoke/yaml/deployment-v2.yaml
@@ -2,18 +2,22 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: basicapp-v2
+  name: basicapp
+  annotations:
+    ploio.io/id: basicapp
+    ploio.io/type: smoke
+    ploio.io/timeout: 5m
 spec:
   replicas: 1
   template:
     metadata:
       labels:
         app: basicapp
-        version: v2
+        version: v2 # This changes so istio rules can use it as a selector for route shaping
     spec:
       containers:
       - name: basicapp
-        image: weavelab/basicapp:v2
+        image: weavelab/basicapp:v2 # note that this is changed to v2 container image
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8000

--- a/test/basicapp/v2-smoke/yaml/routes.yaml
+++ b/test/basicapp/v2-smoke/yaml/routes.yaml
@@ -1,0 +1,28 @@
+apiVersion: config.istio.io/v1alpha2
+kind: RouteRule
+metadata:
+  name: basicapp-default 
+spec:
+  destination:
+    name: basicapp
+  precedence: 1
+  route:
+  - labels:
+      version: v1
+---
+apiVersion: config.istio.io/v1alpha2
+kind: RouteRule
+metadata:
+  name: basicapp-smoke-v2
+spec:
+  destination:
+    name: basicapp
+  precedence: 2
+  match:
+    request:
+      headers:
+        x-ploio-id:
+          regex: "(ploiotest)"
+  route:
+  - labels:
+      version: v2


### PR DESCRIPTION
The idea behind this is to create folders showing exactly what ploio controller will do when presented with a certain custom resource (PloioVersion).

v1 is the initial version of the application that should be deployed before
v2-smoke is how ploio would run a smoke test
v2-canary is how ploio would run a canary test
v2-rolling is how ploio would do a rolling deployment

see #6 